### PR TITLE
Dodanie pola z flagą aktualnego roku

### DIFF
--- a/api/get-routes.php
+++ b/api/get-routes.php
@@ -10,23 +10,25 @@ try {
 	$result = array();
 	
 	if (!empty($area)) {
-		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `areaId` = :areaId ORDER BY `name`');
+		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId`, `currentYear` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `areaId` = :areaId ORDER BY `name`');
 		$stmt->bindValue(':areaId', $area);
 		$stmt->execute();
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $row['currentYear'] = $row['currentYear'] || false;
 			$result[] = $row;
 		}
 		$stmt->closeCursor();
 	} elseif(!empty($territory)) {
-		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `territoryId` = :territoryId ORDER BY `name`');
+		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId`, `currentYear` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `territoryId` = :territoryId ORDER BY `name`');
 		$stmt->bindValue(':territoryId', $territory);
 		$stmt->execute();
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $row['currentYear'] = $row['currentYear'] || false;
 			$result[] = $row;
 		}
 		$stmt->closeCursor();
 	} elseif(!empty($route) && empty($details)) {
-		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId`, `publicAccessSlug` AS `kmlData` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `id` = :id');
+		$stmt = $pdo->prepare('SELECT `id`, `name`, `areaId`, `territoryId`, `currentYear`, `publicAccessSlug` AS `kmlData` FROM `'.AgentTables::EDK_ROUTES.'` WHERE `id` = :id');
 		$stmt->bindValue(':id', $route);
 		$stmt->execute();
 		
@@ -36,12 +38,13 @@ try {
                         $fullUrl = 'http://m2.edk.org.pl/mirror/'.$row['kmlData'].'/edk-gps-route-'.$row['id'].'.kml';
 			
 			$result = $row;
+            $result['currentYear'] = $row['currentYear'] || false;
 			$result['kmlDataPath'] = $fullUrl;
 			$result['stations'] = array();
 		}
 		$stmt->closeCursor();
 	} elseif(!empty($route) && $details == 'full') {
-		$stmt = $pdo->prepare('SELECT r.`id`, r.`name`, r.`areaId`, r.`territoryId`, r.`publicAccessSlug` AS `kmlData`, n.content AS `content` '
+		$stmt = $pdo->prepare('SELECT r.`id`, r.`name`, r.`areaId`, r.`territoryId`, r.`currentYear`, r.`publicAccessSlug` AS `kmlData`, n.content AS `content` '
 			. 'FROM `'.AgentTables::EDK_ROUTES.'` r '
 			. 'LEFT JOIN `'.AgentTables::EDK_ROUTE_NOTES.'` n ON (n.routeId = r.id AND n.noteType = 1) WHERE r.`id` = :id');
 		$stmt->bindValue(':id', $route);
@@ -59,6 +62,7 @@ try {
 					'areaId' => $row['areaId'],
 					'name' => $row['name'],
 					'kmlDataPath' => $fullUrl,
+                    'currentYear' => $row['currentYear'] || false,
 				),
 				'stationDescs' => array(),
 			);

--- a/api/get-routes.php
+++ b/api/get-routes.php
@@ -14,7 +14,7 @@ try {
 		$stmt->bindValue(':areaId', $area);
 		$stmt->execute();
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $row['currentYear'] = $row['currentYear'] || false;
+			$row['currentYear'] = $row['currentYear'] || false;
 			$result[] = $row;
 		}
 		$stmt->closeCursor();
@@ -23,7 +23,7 @@ try {
 		$stmt->bindValue(':territoryId', $territory);
 		$stmt->execute();
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $row['currentYear'] = $row['currentYear'] || false;
+			$row['currentYear'] = $row['currentYear'] || false;
 			$result[] = $row;
 		}
 		$stmt->closeCursor();
@@ -35,10 +35,10 @@ try {
 		$random = rand(0, 100);
 		
 		if($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                        $fullUrl = 'http://m2.edk.org.pl/mirror/'.$row['kmlData'].'/edk-gps-route-'.$row['id'].'.kml';
+			$fullUrl = 'http://m2.edk.org.pl/mirror/'.$row['kmlData'].'/edk-gps-route-'.$row['id'].'.kml';
 			
 			$result = $row;
-            $result['currentYear'] = $row['currentYear'] || false;
+			$result['currentYear'] = $row['currentYear'] || false;
 			$result['kmlDataPath'] = $fullUrl;
 			$result['stations'] = array();
 		}
@@ -62,7 +62,7 @@ try {
 					'areaId' => $row['areaId'],
 					'name' => $row['name'],
 					'kmlDataPath' => $fullUrl,
-                    'currentYear' => $row['currentYear'] || false,
+					'currentYear' => $row['currentYear'] || false,
 				),
 				'stationDescs' => array(),
 			);

--- a/api/x.php
+++ b/api/x.php
@@ -98,7 +98,8 @@ if (sizeof($data->route->ids) > 0) {
 			'registrationType' => (empty($item->registrationType) ? 0 : $item->registrationType),
 			'registrationStartTime' => $item->startTime,
 			'registrationEndTime' => $item->endTime,
-			'externalRegistrationUrl' => $item->externalRegistrationUrl
+			'externalRegistrationUrl' => $item->externalRegistrationUrl,
+            'currentYear' => $item->currentYear ? 1 : 0,
 		));
 	}
 } else {

--- a/api/x.php
+++ b/api/x.php
@@ -99,7 +99,7 @@ if (sizeof($data->route->ids) > 0) {
 			'registrationStartTime' => $item->startTime,
 			'registrationEndTime' => $item->endTime,
 			'externalRegistrationUrl' => $item->externalRegistrationUrl,
-            'currentYear' => $item->currentYear ? 1 : 0,
+			'currentYear' => $item->currentYear ? 1 : 0,
 		));
 	}
 } else {

--- a/src/Cantiga/ExportBundle/Command/ExportCommand.php
+++ b/src/Cantiga/ExportBundle/Command/ExportCommand.php
@@ -33,7 +33,7 @@ class ExportCommand extends ContainerAwareCommand
 		$this
 			->setName('cantiga:export-data')
 			->setDescription('Exports the data to the external services via REST.')
-            ->addOption('current-year-id', 'c', InputOption::VALUE_OPTIONAL, 'Current year project ID')
+			->addOption('current-year-id', 'c', InputOption::VALUE_OPTIONAL, 'Current year project ID')
 		;
 	}
 	
@@ -47,11 +47,11 @@ class ExportCommand extends ContainerAwareCommand
 					$output->writeln($text, OutputInterface::VERBOSITY_NORMAL);
 				});
 				if (!empty($result['route']['update'])) {
-                    $currentYear = (int) $input->getOption('current-year-id') === (int) $export['projectId'];
-                    for ($i = 0, $count = count($result['route']['update']); $i < $count; $i++) {
-                        $result['route']['update'][$i]['currentYear'] = $currentYear;
-                    }
-                }
+					$currentYear = (int) $input->getOption('current-year-id') === (int) $export['projectId'];
+					for ($i = 0, $count = count($result['route']['update']); $i < $count; $i++) {
+						$result['route']['update'][$i]['currentYear'] = $currentYear;
+					}
+				}
 				if ($this->send($export, $this->encrypt($export, $result), $output)) {
 					$output->writeln('<info>Export completed</info>');
 				} else {

--- a/src/Cantiga/ExportBundle/Command/ExportCommand.php
+++ b/src/Cantiga/ExportBundle/Command/ExportCommand.php
@@ -21,6 +21,7 @@ namespace Cantiga\ExportBundle\Command;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ExportCommand extends ContainerAwareCommand
@@ -32,6 +33,7 @@ class ExportCommand extends ContainerAwareCommand
 		$this
 			->setName('cantiga:export-data')
 			->setDescription('Exports the data to the external services via REST.')
+            ->addOption('current-year-id', 'c', InputOption::VALUE_OPTIONAL, 'Current year project ID')
 		;
 	}
 	
@@ -44,6 +46,12 @@ class ExportCommand extends ContainerAwareCommand
 				$result = $exportEngine->exportData($export, function($text) use($output) {
 					$output->writeln($text, OutputInterface::VERBOSITY_NORMAL);
 				});
+				if (!empty($result['route']['update'])) {
+                    $currentYear = (int) $input->getOption('current-year-id') === (int) $export['projectId'];
+                    for ($i = 0, $count = count($result['route']['update']); $i < $count; $i++) {
+                        $result['route']['update'][$i]['currentYear'] = $currentYear;
+                    }
+                }
 				if ($this->send($export, $this->encrypt($export, $result), $output)) {
 					$output->writeln('<info>Export completed</info>');
 				} else {


### PR DESCRIPTION
Z opisu potrzebnej zmiany zrozumiałem tyle, że:

1. modyfikuję tabelę `cantiga_edk_routes` w bazie danych `rejony-app` dodając nowe pole `TINYINT`/`BOOLEAN` z flagą aktualnego roku (jest aktualny lub nie),
2. modyfikuję commanda wysyłającego zmiany bazy do zewnętrznej tabeli o nowe pole,
3. modyfikuję skrypt odbierający dane, który ma odbierać dodatkowe pole i zapisywać je w bazie danych,
4. modyfikuję tabelę bazy danych API dodając nowe pole,
5. modyfikuję plik `get-routes.php` z API, żeby zwracał nowe pole.

Realizacja wyglądała jednak tak:

1. tabelę `cantiga_edk_routes` trzeba zmodyfikować dokładając pole `currentYear` ale nie bardzo wiem, jak mam to zrobić, bo w domyślnej strukturze bazy znajdującej się w repozytorium nie ma takiej tabeli, a projekt nie obsługuje Doctrine migrations,
2. commanda `cantiga:export-data` nie trzeba modyfikować, bo wysyła wszystkie pola z tabeli `cantiga_edk_routes` - wystarczy dodać pole,
3. skryptu do odbierania danych z commanda nie znalazłem w repozytorium (może coś pominąłem...),
4. struktury bazy danych API również nie znalazłem nigdzie,
5. do zmiany pozostał więc tylko plik `get-routes.php`, który zmodyfikowałem.

Proszę o informacje, co jeszcze w tej kwestii jest do zrobienia.