### PR TITLE
Bugfix: Zmiana szyfrowania API

### DIFF
--- a/api/config.dist.php
+++ b/api/config.dist.php
@@ -1,0 +1,9 @@
+<?php
+
+define('DB_HOST', '');
+define('DB_NAME', '');
+define('DB_PASS', '');
+define('DB_USER', '');
+
+define('ENCRYPTION_ALGORITHM', 'aes-256-cbc');
+define('ENCRYPTION_KEY', '');

--- a/api/inc.php
+++ b/api/inc.php
@@ -1,9 +1,12 @@
 <?php
-$pdo = new PDO('mysql:host=localhost;dbname=11920893_panel', '11920893_panel', '');
+if (!file_exists('./config.php')) {
+	die('config.php file is required!');
+}
+require_once('./config.php');
+
+$pdo = new PDO('mysql:host=' . DB_HOST . ';dbname=' . DB_NAME, DB_USER, DB_PASS);
 $pdo->query('SET NAMES `utf8`');
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-define('ENC_KEY', 'TA7ZiF4q+T+xBhffZdggIFWiORcA0YElL466vw9RJNc=');
 
 class AgentTables {
 	const EDK_TERRITORIES = 'edk_territories';

--- a/api/x.php
+++ b/api/x.php
@@ -8,19 +8,19 @@ if ($_SERVER['REQUEST_METHOD'] != 'POST') {
 header('HTTP/1.1 200 OK');
 header('Content-Type: text/html; charset=UTF-8');
 
-$ivSize = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC);
-$decrypted = base64_decode(file_get_contents('php://input'));
-if (false === $decrypted) {
+$ivSize = openssl_cipher_iv_length(ENCRYPTION_ALGORITHM);
+$encrypted = base64_decode(file_get_contents('php://input'));
+if (false === $encrypted) {
 	die('');
 }
 
-if (strlen($decrypted) <= $ivSize) {
+if (strlen($encrypted) <= $ivSize) {
 	die('');
 }
-$ivDec = substr($decrypted, 0, $ivSize);
-$message = substr($decrypted, $ivSize);
+$iv = substr($encrypted, 0, $ivSize);
+$message = substr($encrypted, $ivSize);
 
-$decrypted = trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, base64_decode(ENC_KEY), $message, MCRYPT_MODE_CBC, $ivDec));
+$decrypted = trim(openssl_decrypt($message, ENCRYPTION_ALGORITHM, base64_decode(ENCRYPTION_KEY), true, $iv));
 if (false === $decrypted) {
 	die('');
 }


### PR DESCRIPTION
Szyfrowanie zmienione na zgodne z tym, którym szyfruje Cantiga. Przy okazji stworzyłem osobny plik z ustawieniami, który nie jest commitowany do repozytorium (jego "szablon" to `config.dist.php` - dlatego nie `config.php.dist`, żeby plik ten też był wykonywalny, skoro będzie znajdował się w folderze dostępnym po HTTP).

Po przeniesieniu API do osobnego repozytorium (byłoby bardzo dobrze stworzyć osobne repo, np. `rejony-api`) trzeba dodać `config.php` do `.gitignore`.