### PR TITLE
#45 - błąd 500 przy zwracaniu zgłoszenia użytkownika

### DIFF
--- a/src/Cantiga/CoreBundle/Entity/AreaRequest.php
+++ b/src/Cantiga/CoreBundle/Entity/AreaRequest.php
@@ -65,8 +65,8 @@ class AreaRequest implements IdentifiableInterface, InsertableEntityInterface, E
 			. 'INNER JOIN `'.CoreTables::TERRITORY_TBL.'` t ON t.`id` = r.`territoryId` '
 			. 'LEFT JOIN `'.CoreTables::USER_TBL.'` v ON v.`id` = r.`verifierId` '
 			. 'WHERE r.`id` = :id AND r.`requestorId` = :requestorId', [':id' => $id, ':requestorId' => $requestor->getId()]);
-		if(null === $data) {
-			return false;
+		if (!is_array($data)) {
+			return null;
 		}
 		$project = Project::fetch($conn, $data['projectId']);
 		$item = self::fromArray($data);


### PR DESCRIPTION
Naprawa błędu #45 - metoda `Cantiga\CoreBundle\Entity\AreaRequest::fetchByRequestor` nie zwracała `false` w przypadku braku zgłoszenia użytkownika o podanym ID (warunek był błędny), a nawet jeśli by zwracała, powodowałoby to błędy na dalszym etapie (np. w `Cantiga\CoreBundle\Repository\UserAreaRequestRepository::getItem`), gdzie wymagana jest tablica bądź `null` - po długim dochodzeniu poprawiłem jedno i drugie.
Nie wiem tylko, dlaczego użytkownikowi zwrócono link z niepoprawnym ID zgłoszenia.