### PR TITLE
Feature: Poprawa działania small-box

### DIFF
--- a/web/css/cantiga.css
+++ b/web/css/cantiga.css
@@ -554,3 +554,12 @@ div.progress-box div.progress-box-link {
   font-weight: 400;
   font-size: 12px;
 }
+.small-box h3,
+.small-box p {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.small-box h3:after,
+.small-box p:after {
+  content: "\00a0";
+}


### PR DESCRIPTION
Zapobiega wylewaniu się tekstu za small-box i nienaturalnemu zmniejszaniu wysokości, jeśli nagłówek albo opis są puste (wtedy ikona w tle wylewała się na zewnątrz) - takie sytuacje się zdarzają.