### PR TITLE
Bugfix: Zapobieganie wywalania wyjątku przy edycji zapisów trasy

### DIFF
--- a/src/WIO/EdkBundle/Entity/EdkRegistrationSettings.php
+++ b/src/WIO/EdkBundle/Entity/EdkRegistrationSettings.php
@@ -160,13 +160,11 @@ class EdkRegistrationSettings implements IdentifiableInterface, EditableEntityIn
 		} elseif ($this->registrationType == self::TYPE_OTHER) {
 			$this->checkUnsupportedFields($context, ['externalRegistrationUrl', 'participantLimit', 'maxPeoplePerRecord', 'customQuestion']);
 		}
-		if ($this->registrationType != self::TYPE_NO) {
-			$this->externalParticipantNum = (int) $this->externalParticipantNum;
-			if ($this->externalParticipantNum < 0) {
-				$context->buildViolation('ExternalParticipantNumInvalidErrMsg')
-					->atPath('externalParticipantNum')
-					->addViolation();
-			}
+		$this->externalParticipantNum = (int) $this->externalParticipantNum;
+		if ($this->registrationType != self::TYPE_NO && $this->externalParticipantNum < 0) {
+			$context->buildViolation('ExternalParticipantNumInvalidErrMsg')
+				->atPath('externalParticipantNum')
+				->addViolation();
 		}
 	}
 	


### PR DESCRIPTION
Podczas edycji trasy w ustawieniach zapisów tras, jeśli wybrano sposób zapisów "Brak zapisów" i nie podano wartości w polu "Liczba uczestników zapisanych przez zewnętrzne zapisy", rzucany jest wyjątek przy edycji rekordu w bazie (pole `externalParticipantNum` nie przyjmuje wartości `null`). Ta poprawka mapuje w/w pole na `int` niezależnie od sposobu zapisów, co w przypadku braku wartości w w/w polu przypisze mu wartość 0.