### PR TITLE
Feature: Poprawa wyboru trasy przy rejestracji użytkownika

### DIFF
--- a/src/Cantiga/CoreBundle/Api/Actions/InsertAction.php
+++ b/src/Cantiga/CoreBundle/Api/Actions/InsertAction.php
@@ -72,7 +72,7 @@ class InsertAction extends AbstractAction
 		return $this;
 	}
 		
-	public function run(CantigaController $controller, Request $request)
+	public function run(CantigaController $controller, Request $request, int $routeId = null)
 	{
 		try {
 			$repository = $this->info->getRepository();
@@ -114,7 +114,8 @@ class InsertAction extends AbstractAction
 			$vars['insertPage'] = $this->info->getInsertPage();
 			$vars['editPage'] = $this->info->getEditPage();
 			$vars['removePage'] = $this->info->getRemovePage();
-			
+			$vars['route'] = $routeId;
+
 			return $controller->render($this->info->getTemplateLocation().'insert.html.twig', $vars);
 		} catch(ItemNotFoundException $exception) {
 			return $this->onError($controller, $controller->trans($this->info->getItemNotFoundErrorMessage()));

--- a/src/WIO/EdkBundle/Controller/AreaParticipantController.php
+++ b/src/WIO/EdkBundle/Controller/AreaParticipantController.php
@@ -159,8 +159,11 @@ class AreaParticipantController extends AreaPageController
 			$entity = EdkParticipant::newParticipant();
 
 			if ($request->getMethod() == 'POST') {
-				$entity->setRegistrationSettings($settingsRepository->getItem($request->get('route', null)));
+				$routeId = $request->request->get('route');
+				$entity->setRegistrationSettings($settingsRepository->getItem($routeId));
 				$entity->setIpAddress(ip2long($_SERVER['REMOTE_ADDR']));
+			} else {
+				$routeId = null;
 			}
 
 			$action = new InsertAction($this->crudInfo, $entity);
@@ -174,7 +177,7 @@ class AreaParticipantController extends AreaPageController
 				]);
 			});
 			$action->set('ajaxRoutePage', 'area_edk_participant_ajax_routes');
-			return $action->run($this, $request);
+			return $action->run($this, $request, $routeId);
 		} catch(ItemNotFoundException $exception) {
 			return $this->showPageWithError($this->trans($exception->getMessage(), [], 'edk'), 'area_edk_participant_index', ['slug' => $this->getSlug()]);
 		}

--- a/src/WIO/EdkBundle/Resources/views/AreaParticipant/insert.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/AreaParticipant/insert.html.twig
@@ -12,7 +12,7 @@
 			<fieldset>
 				<legend>{{ 'Choose the route' | trans([], 'public') }}</legend>
 				<div class="form-group col-lg-4">
-					<select name="route" class="form-control" id="route"></select>
+					<select name="route" class="form-control" id="route" data-route-selected="{{ route }}"></select>
 				</div>
 				<div id="details">
 				</div>

--- a/web/js/registratr.js
+++ b/web/js/registratr.js
@@ -3,9 +3,12 @@
 		var opts = $.extend( {}, $.fn.registratr.defaults, options );
 		var root = $(this);
 		var routes = new Array();
+		var routeElem;
+		var selectedRouteId = 0;
 		
 		if (null !== opts['routeSelector'] && null !== opts['routeUrl']) {
-			var routeElem = root.find(opts['routeSelector']);
+			routeElem = root.find(opts['routeSelector']);
+			selectedRouteId = parseInt(routeElem.data('route-selected'), 10);
 			routeElem.change(function() {
 				var presenter = root.find(opts['routePresenter']);
 				if (routes[routeElem.val()]) {
@@ -71,7 +74,7 @@
 				url: opts['routeUrl'],
 				dataType: "json",
 				success: function (result) {
-					disableEverything()
+					disableEverything();
 					renderSelector(result);
 				}
 			});
@@ -129,9 +132,16 @@
 			}
 			routeElem.empty();
 			routeElem.append(code);
+
+			if (selectedRouteId > 0) {
+				routeElem.val(selectedRouteId);
+				routeElem.trigger('change');
+				selectedRouteId = 0;
+			}
+
 			data = result;
 		}
-	}
+	};
 	
 	$.fn.registratr.defaults = {
 		routeSelector: null,
@@ -145,6 +155,6 @@
 		estimatedParticipantNumText: '',
 		participantNumText: '',
 		inspiredWarningText: '',
-		additionalInformationText: '',
+		additionalInformationText: ''
 	};
 }(jQuery));


### PR DESCRIPTION
Zauważyłem, że podczas dodawania uczestnika do trasy z poziomu przestrzeni rejonu, jeśli walidator nie przepuści formularza, formularz staje się na powrót nieaktywny, bo poprzednio wybrana trasa nie zostaje wybrana automatycznie przy załadowaniu formularza z komunikatami błędów (trasy dociągają się AJAXem). Ta poprawka przekazuje do JSa obsługującego ładowanie tras ID wybranej wcześniej trasy, co zapobiega wyświetlaniu nieaktywnego formularza i potrzebie ponownego wyboru trasy w przypadku zwrócenia formularza z komunikatami błędów.
Uważam tę sprawę za poważną na tyle, że proszę o merge do brancha `master`, zamiast do `2017`.