### PR TITLE
Bugfix: Regeneracja wartości publicAccessSlug przy edycji trasy

### DIFF
--- a/src/WIO/EdkBundle/Entity/EdkRoute.php
+++ b/src/WIO/EdkBundle/Entity/EdkRoute.php
@@ -629,6 +629,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	
 	public function update(Connection $conn)
 	{
+		$this->publicAccessSlug = sha1(time() . $this->routeAscent . $this->routeFrom . rand(-20000, 20000));
 		$this->updatedAt = time();
 		
 		if (null !== $this->postedMessage) {


### PR DESCRIPTION
Wymusza to przeładowanie danych cache'owanych np. przez Google Maps. Zmiana działa (trasa na mapie jest przeładowywana) ale ponieważ nie znam wszystkich zależności w systemie, nie wiem, czy takie zmiany nie wpływają na coś innego w innym miejscu. Sprawdźcie to, proszę przed wdrożeniem poprawki.