### PR TITLE
Bugfix #48: Poprawa błędu 500 na liście tras

### DIFF
--- a/src/Cantiga/CoreBundle/Entity/AppMail.php
+++ b/src/Cantiga/CoreBundle/Entity/AppMail.php
@@ -43,7 +43,7 @@ class AppMail implements IdentifiableInterface, InsertableEntityInterface, Edita
 	public static function fetchById(Connection $conn, $id)
 	{
 		$data = $conn->fetchAssoc('SELECT * FROM `'.CoreTables::MAIL_TBL.'` WHERE `id` = :id', [':id' => $id]);
-		if(null === $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		return self::fromArray($data);

--- a/src/Cantiga/CoreBundle/Entity/Area.php
+++ b/src/Cantiga/CoreBundle/Entity/Area.php
@@ -76,7 +76,7 @@ class Area implements IdentifiableInterface, InsertableEntityInterface, Editable
 			. 'INNER JOIN `'.CoreTables::TERRITORY_TBL.'` t ON t.`id` = a.`territoryId` '
 			. self::createPlaceJoin('a')
 			. 'INNER JOIN `'.CoreTables::PROJECT_TBL.'` p ON p.`id` = a.`projectId` WHERE a.`id` = :id', [':id' => $id]);
-		if(null === $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		$item = Area::fromArray($data);
@@ -110,7 +110,7 @@ class Area implements IdentifiableInterface, InsertableEntityInterface, Editable
 			. 'INNER JOIN `'.CoreTables::PROJECT_TBL.'` p ON p.`id` = a.`projectId` '
 			. 'WHERE a.`name` = :name AND a.`projectId` = :parentProject AND m.`userId` = :userId', [
 				':name' => $currentArea->getName(), ':parentProject' => $currentArea->getProject()->getParentProject()->getId(), ':userId' => $user->getId()]);
-		if(null == $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		$item = Area::fromArray($data);
@@ -150,7 +150,7 @@ class Area implements IdentifiableInterface, InsertableEntityInterface, Editable
 			. self::createPlaceJoin('a')
 			. 'INNER JOIN `'.CoreTables::TERRITORY_TBL.'` t ON t.`id` = a.`territoryId` '
 			. 'WHERE a.`id` = :id AND '.$selector, [':id' => $id, ':placeId' => $place->getId()]);
-		if(false === $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		$item = Area::fromArray($data);
@@ -178,7 +178,7 @@ class Area implements IdentifiableInterface, InsertableEntityInterface, Editable
 			. self::createPlaceJoin('a')
 			. 'INNER JOIN `'.CoreTables::TERRITORY_TBL.'` t ON t.`id` = a.`territoryId` '
 			. 'WHERE a.`placeId` = :placeId', [':placeId' => $place->getId()]);
-		if(false === $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		$area = self::fromArray($data);

--- a/src/Cantiga/CoreBundle/Entity/AreaRequest.php
+++ b/src/Cantiga/CoreBundle/Entity/AreaRequest.php
@@ -87,7 +87,7 @@ class AreaRequest implements IdentifiableInterface, InsertableEntityInterface, E
 			. 'INNER JOIN `'.CoreTables::TERRITORY_TBL.'` t ON t.`id` = r.`territoryId` '
 			. 'LEFT JOIN `'.CoreTables::USER_TBL.'` v ON v.`id` = r.`verifierId` '
 			. 'WHERE r.`id` = :id AND r.`projectId` = :projectId', [':id' => $id, ':projectId' => $project->getId()]);
-		if(null === $data) {
+		if (!is_array($data)) {
 			return false;
 		}
 		$user = User::fetchByCriteria($conn, QueryClause::clause('u.`id` = :id', ':id', $data['requestorId']));

--- a/src/Cantiga/CoreBundle/Repository/LanguageRepository.php
+++ b/src/Cantiga/CoreBundle/Repository/LanguageRepository.php
@@ -89,7 +89,7 @@ class LanguageRepository implements EntityTransformerInterface
 		$this->transaction->requestTransaction();
 		$data = $this->conn->fetchAssoc('SELECT * FROM `'.CoreTables::LANGUAGE_TBL.'` WHERE `id` = :id', [':id' => $id]);
 		
-		if(null === $data) {
+		if (!is_array($data)) {
 			$this->transaction->requestRollback();
 			throw new ItemNotFoundException('The specified language has not been found.', $id);
 		}


### PR DESCRIPTION
To jest stosunkowo ważne, bo w pewnych okolicznościach uniemożliwia koordynatorowi rejonu wejście na listę tras. @zaquncio: możemy to wrzucić też w tym tygodniu razem ze zmianą formularza?