### PR TITLE
Bugfix #39: Problem z usuwaniem trasy

### DIFF
--- a/src/Cantiga/CoreBundle/Entity/AreaRequest.php
+++ b/src/Cantiga/CoreBundle/Entity/AreaRequest.php
@@ -370,13 +370,14 @@ class AreaRequest implements IdentifiableInterface, InsertableEntityInterface, E
 		return $cnt;
 	}
 	
-	public function remove(Connection $conn)
+	public function remove(Connection $conn): int
 	{
 		$this->status = $conn->fetchColumn('SELECT `status` FROM `'.CoreTables::AREA_REQUEST_TBL.'` WHERE `id` = :id', [':id' => $this->id]);
 		if ($this->canRemove()) {
 			DataMappers::recount($conn, CoreTables::TERRITORY_TBL, $this->territory, null, 'requestNum', 'id');
-			$conn->delete(CoreTables::AREA_REQUEST_TBL, DataMappers::pick($this, ['id']));
+			return $conn->delete(CoreTables::AREA_REQUEST_TBL, DataMappers::pick($this, ['id']));
 		}
+		return 0;
 	}
 	
 	public function startVerification(Connection $conn, User $verifier)

--- a/src/Cantiga/CoreBundle/Repository/ProjectAreaRequestRepository.php
+++ b/src/Cantiga/CoreBundle/Repository/ProjectAreaRequestRepository.php
@@ -227,7 +227,7 @@ class ProjectAreaRequestRepository
 	{
 		$this->transaction->requestTransaction();
 		try {
-			if (!$item->remove($this->conn)) {
+			if ($item->remove($this->conn) < 1) {
 				throw new ModelException('Cannot remove the specified area request.');
 			}
 		} catch(Exception $exception) {

--- a/src/Cantiga/CoreBundle/Repository/UserAreaRequestRepository.php
+++ b/src/Cantiga/CoreBundle/Repository/UserAreaRequestRepository.php
@@ -220,7 +220,7 @@ class UserAreaRequestRepository implements EntityTransformerInterface
 	{
 		$this->transaction->requestTransaction();
 		try {
-			if (!$item->remove($this->conn)) {
+			if ($item->remove($this->conn) < 1) {
 				throw new ModelException('Cannot remove the specified area request.');
 			}
 		} catch(Exception $exception) {


### PR DESCRIPTION
Metoda `AreaRequest::remove` nie zwracała żadnej wartości (więc zwracany był `null`), co powodowało rzucanie `ModelException` wewnątrz metod `UserAreaRequestRepository::remove` i `ProjectAreaRequestRepository::remove` (bez względu na wartość zwracaną przez metodę `Connection::delete`), co z kolei powodowało wycofywanie transakcji za każdym razem.

Rzuciłem okiem na ten problem w Cantiga - tam już został rozwiązany, choć w ciut inny sposób. @zaquncio: jeśli chcesz, mogę przerobić to tak, jak jest tam (daj znać lub zrób merge).