### PR TITLE
Bugfix #100: Zbyt wysoki modal

### DIFF
--- a/src/Cantiga/DiscussionBundle/Resources/views/Discussion/discussion.html.twig
+++ b/src/Cantiga/DiscussionBundle/Resources/views/Discussion/discussion.html.twig
@@ -104,7 +104,7 @@
 
 {% block javascripts_inline %}
 	<script>
-		$('#discussion-content').summernote({ lang: '{{ user.settingsLanguage.locale }}', airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'discussion') }}', popover: {
+		$('#discussion-content').summernote({ lang: '{{ user.settingsLanguage.locale }}', dialogsInBody: true, airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'discussion') }}', popover: {
 			air: [
 				['link', ['link', 'unlink']],
 				['font', ['bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript']], 

--- a/src/WIO/EdkBundle/Resources/views/EdkNote/index.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/EdkNote/index.html.twig
@@ -62,7 +62,7 @@
 		});
 	</script>
 	<script>
-		$('#note-content-editor').summernote({ lang: '{{ user.settingsLanguage.locale }}', airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'edk') }}', popover: {
+		$('#note-content-editor').summernote({ lang: '{{ user.settingsLanguage.locale }}', dialogsInBody: true, airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'edk') }}', popover: {
 			air: [
 				['link', ['link', 'unlink']],
 				['font', ['bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript']], 

--- a/src/WIO/EdkBundle/Resources/views/EdkRoute/info.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/EdkRoute/info.html.twig
@@ -213,7 +213,7 @@
 		});
 	</script>
 	<script>
-		$('#note-content-editor').summernote({ lang: '{{ user.settingsLanguage.locale }}', airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'edk') }}', popover: {
+		$('#note-content-editor').summernote({ lang: '{{ user.settingsLanguage.locale }}', dialogsInBody: true, airMode: true, placeholder: '{{ 'EditorStartTypingPlaceholder' | trans([], 'edk') }}', popover: {
 			air: [
 				['link', ['link', 'unlink']],
 				['font', ['bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript']], 

--- a/web/css/cantiga.css
+++ b/web/css/cantiga.css
@@ -563,3 +563,12 @@ div.progress-box div.progress-box-link {
 .small-box p:after {
   content: "\00a0";
 }
+.modal-dialog {
+  max-height: calc(100% - 2 * 10px);
+  overflow-y: auto;
+}
+@media (min-width: 768px) {
+  .modal-dialog {
+    max-height: calc(100% - 2 * 30px);
+  }
+}


### PR DESCRIPTION
Ustaliłem maksymalną wysokość modala i dodałem scrollowanie w pionie. Dodatkowo dodałem do niektórych instancji edytora Summernote parametr dialogsInBody, który dopina modale edytora do <body>, żeby uniknąć otwierania jednego modala wewnątrz innego.