### PR TITLE
Bugfix #88: Rozwiązanie problemu nieprawidłowych dat

### DIFF
--- a/src/Cantiga/UserBundle/EventListener/TimezoneListener.php
+++ b/src/Cantiga/UserBundle/EventListener/TimezoneListener.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Cantiga\UserBundle\EventListener;
+
+use Cantiga\CoreBundle\Entity\User;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+
+/**
+ * Event listener
+ */
+class TimezoneListener
+{
+	/** @var AuthorizationCheckerInterface */
+	private $authorizationChecker;
+
+	/** @var TokenStorage */
+	private $tokenStorage;
+
+	/**
+	 * Constructor
+	 *
+	 * @param AuthorizationCheckerInterface $authorizationChecker authorization checker
+	 * @param TokenStorage                  $tokenStorage         token storage
+	 */
+	public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorage $tokenStorage)
+	{
+		$this->authorizationChecker = $authorizationChecker;
+		$this->tokenStorage = $tokenStorage;
+	}
+
+	/**
+	 * On kernel request
+	 */
+	public function onKernelRequest()
+	{
+		$token = $this->tokenStorage->getToken();
+		if (!isset($token)) {
+			return;
+		}
+
+		if (!$this->authorizationChecker->isGranted('ROLE_USER')) {
+			return;
+		}
+
+		$user = $token->getUser();
+		if (!($user instanceof User) || empty($user->getSettingsTimezone())) {
+			return;
+		}
+
+		date_default_timezone_set($user->getSettingsTimezone());
+	}
+}

--- a/src/Cantiga/UserBundle/Resources/config/services.yml
+++ b/src/Cantiga/UserBundle/Resources/config/services.yml
@@ -39,6 +39,11 @@ services:
             - { name: kernel.event_listener, event: cantiga.workspace.group, method: onGroupWorkspace }
             - { name: kernel.event_listener, event: cantiga.workspace.area, method: onAreaWorkspace }
             - { name: kernel.event_listener, event: cantiga.workspace.user, method: onUserWorkspace }
+    cantiga.user.timezone_listener:
+        class: Cantiga\UserBundle\EventListener\TimezoneListener
+        arguments: ["@security.authorization_checker", "@security.token_storage"]
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
     cantiga.user.role.voter:
          class: Cantiga\UserBundle\Auth\PlaceRoleVoter
          arguments: ["@cantiga.user.membership.storage"]

--- a/src/WIO/EdkBundle/Controller/RegistrationSettingsController.php
+++ b/src/WIO/EdkBundle/Controller/RegistrationSettingsController.php
@@ -120,7 +120,7 @@ class RegistrationSettingsController extends WorkspaceController
 	 */
 	public function editAction($id, Request $request)
 	{
-		$action = new EditAction($this->crudInfo, EdkRegistrationSettingsForm::class, ['timezone' => new DateTimeZone($this->getUser()->getSettingsTimezone())]);
+		$action = new EditAction($this->crudInfo, EdkRegistrationSettingsForm::class);
 		$action->slug($this->getSlug());
 		return $action->run($this, $id, $request);
 	}

--- a/src/WIO/EdkBundle/Form/EdkRegistrationSettingsForm.php
+++ b/src/WIO/EdkBundle/Form/EdkRegistrationSettingsForm.php
@@ -36,8 +36,6 @@ class EdkRegistrationSettingsForm extends AbstractType
 {
 	public function configureOptions(OptionsResolver $resolver)
 	{
-		$resolver->setDefined(['timezone']);
-		$resolver->setRequired(['timezone']);
 		$resolver->setDefaults(array(
 			'translation_domain' => 'edk'
 		));
@@ -55,7 +53,6 @@ class EdkRegistrationSettingsForm extends AbstractType
 				'years' => $this->currentYears(),
 				'input' => 'timestamp',
 				'model_timezone' => 'UTC',
-				'view_timezone' => $options['timezone']->getName(),
 				'required' => false,
 			))
 			->add('endTime', DateTimeType::class, array(
@@ -63,7 +60,6 @@ class EdkRegistrationSettingsForm extends AbstractType
 				'years' => $this->currentYears(),
 				'input' => 'timestamp',
 				'model_timezone' => 'UTC',
-				'view_timezone' => $options['timezone']->getName(),
 				'required' => false
 			))
 			->add('externalRegistrationUrl', UrlType::class, ['label' => 'External registration URL', 'attr' => ['help_text' => 'ExternalRegistrationUrlHint'], 'required' => false])


### PR DESCRIPTION
Problem polega na tym, że użytkownik może ustawić swoją strefę czasową ale później strefa ta nie jest ustawiana przy pomocy funkcji `date_default_timezone_set` ani w żaden iny sposób, więc wszystkie daty widoczne są w domyślnej strefie serwera (np. w `UTC`). Rozwiązanie to dodanie event listenera, który ustawia zalogowanemu użytkownikowi zdefiniowaną przez niego strefę czasową. Usunąłem też definiowanie strefy czasowej dla formularza `EdkRegistrationSettingsForm`, bo i tak zostanie wzięta domyślna, czyli poprawna, choć trzeba to jeszcze dobrze wytestować przed wdrożeniem.